### PR TITLE
Added multiline mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,16 @@ use cargo_lock::Lockfile;
 fn main() {
     let args: Vec<String> = env::args().collect();
     let mut maxlen_mode = false;
+    let mut multiline_mode = false;
 
     let lockfile = match args.len() {
         1 => "Cargo.lock",
         2 => &args[1],
         3 => if args[1] == "--align=maxlen" {
             maxlen_mode = true;
+            &args[2]
+        } else if args[1] == "--align=multiline" {
+            multiline_mode = true;
             &args[2]
         } else {
             print_usage(1)
@@ -57,6 +61,11 @@ fn main() {
                        checksum,
                        name_width = name_min_width,
                        version_width = version_min_width);
+            } else if multiline_mode {
+                print!("    {} \\\n    {} \\\n    {}",
+                       package.name,
+                       package.version,
+                       checksum);
             } else {
                 print!("    {:<name_width$}  {:>version_width$}  {}",
                        package.name,
@@ -72,6 +81,6 @@ fn main() {
 
 fn print_usage(code: i32) -> &'static str {
     let arg0 = env::args().next().unwrap_or("cargo2port".to_owned());
-    eprintln!("Usage: {} [--align=maxlen] <path/to/Cargo.lock>", arg0);
+    eprintln!("Usage: {} [--align=maxlen|multiline] <path/to/Cargo.lock>", arg0);
     process::exit(code);
 }


### PR DESCRIPTION
This mode is format `cargo.crates` which is used at least inside `cargo-c` Portfile.