### PR TITLE
feat: Read from stdin with `-` parameter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,11 @@ fn main() {
 }
 
 fn check_path(arg: &str) -> Option<String> {
-    let path = Path::new(&arg);
+    if arg == "-" {
+        return Some(arg.to_string());
+    }
 
+    let path = Path::new(&arg);
     match path.try_exists() {
         Ok(true) => {
             if path.is_file() {


### PR DESCRIPTION
If the input parameters includes `-`, a single Cargo.lock file is read
from standard input and processed.

This will allow chaining commands like:

```console
$ curl -fsSL https://crates.io/api/v1/crates/mise/2024.8.5/download |
    tar xz - -O '*/Cargo.lock' |
    cargo2port - --align=justify
```
