### PR TITLE
refactor: Document library use of cargo2port

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,12 @@ use std::env;
 use std::path::Path;
 use std::process;
 
-use cargo2port::{format_cargo_crates, read_packages_from_lockfiles, AlignmentMode};
+use cargo_lock::{Lockfile, Package};
+
+use cargo2port::{
+    format_cargo_crates, lockfile_from_path, lockfile_from_stdin, resolve_lockfile_packages,
+    AlignmentMode, Result,
+};
 
 fn main() {
     let mut mode = AlignmentMode::Normal;
@@ -76,6 +81,22 @@ fn check_path(arg: &str) -> Option<String> {
             process::exit(1);
         }
     }
+}
+
+fn read_packages_from_lockfiles(files: &Vec<String>) -> Result<Vec<Package>> {
+    let mut lockfiles: Vec<Lockfile> = vec![];
+
+    for name in files {
+        let lockfile = if name == "-" {
+            lockfile_from_stdin()?
+        } else {
+            lockfile_from_path(name)?
+        };
+
+        lockfiles.push(lockfile);
+    }
+
+    resolve_lockfile_packages(&lockfiles)
 }
 
 fn print_usage(code: i32) {

--- a/tests/duplicate_file_test.rs
+++ b/tests/duplicate_file_test.rs
@@ -1,10 +1,17 @@
 use std::io::Write;
 
-use cargo2port::{format_cargo_crates, read_packages_from_lockfiles, AlignmentMode};
+use cargo2port::{
+    format_cargo_crates, lockfile_from_path, resolve_lockfile_packages, AlignmentMode,
+};
+use cargo_lock::Package;
 use goldenfile::Mint;
 
-fn lockfiles() -> Vec<String> {
-    vec!["Cargo.lock".to_string(), "Cargo.lock".to_string()]
+fn lockfiles() -> Vec<Package> {
+    let files = vec!["Cargo.lock".to_string(), "Cargo.lock".to_string()]
+        .into_iter()
+        .map(|f| lockfile_from_path(&f).unwrap())
+        .collect();
+    resolve_lockfile_packages(&files).unwrap()
 }
 
 #[test]
@@ -12,7 +19,7 @@ fn test_duplicate_file_normal_mode() {
     let mut mint = Mint::new("tests/support");
     let mut file = mint.new_goldenfile("one_file_normal").unwrap();
 
-    let packages = read_packages_from_lockfiles(&lockfiles()).unwrap();
+    let packages = lockfiles();
     let output = format_cargo_crates(packages, AlignmentMode::Normal);
 
     writeln!(file, "{}", output).unwrap();
@@ -23,7 +30,7 @@ fn test_duplicate_file_maxlen_mode() {
     let mut mint = Mint::new("tests/support");
     let mut file = mint.new_goldenfile("one_file_maxlen").unwrap();
 
-    let packages = read_packages_from_lockfiles(&lockfiles()).unwrap();
+    let packages = lockfiles();
     let output = format_cargo_crates(packages, AlignmentMode::Maxlen);
 
     writeln!(file, "{}", output).unwrap();
@@ -34,7 +41,7 @@ fn test_duplicate_file_multiline_mode() {
     let mut mint = Mint::new("tests/support");
     let mut file = mint.new_goldenfile("one_file_multiline").unwrap();
 
-    let packages = read_packages_from_lockfiles(&lockfiles()).unwrap();
+    let packages = lockfiles();
     let output = format_cargo_crates(packages, AlignmentMode::Multiline);
 
     writeln!(file, "{}", output).unwrap();
@@ -45,7 +52,7 @@ fn test_duplicate_file_justify_mode() {
     let mut mint = Mint::new("tests/support");
     let mut file = mint.new_goldenfile("one_file_justify").unwrap();
 
-    let packages = read_packages_from_lockfiles(&lockfiles()).unwrap();
+    let packages = lockfiles();
     let output = format_cargo_crates(packages, AlignmentMode::Justify);
 
     writeln!(file, "{}", output).unwrap();

--- a/tests/multi_file_test.rs
+++ b/tests/multi_file_test.rs
@@ -1,13 +1,20 @@
 use std::io::Write;
 
-use cargo2port::{format_cargo_crates, read_packages_from_lockfiles, AlignmentMode};
+use cargo2port::{
+    format_cargo_crates, lockfile_from_path, resolve_lockfile_packages, AlignmentMode,
+};
+use cargo_lock::Package;
 use goldenfile::Mint;
 
-fn lockfiles() -> Vec<String> {
-    vec![
+fn lockfiles() -> Vec<Package> {
+    let files = vec![
         "tests/support/multi_lockfile_one".to_string(),
         "tests/support/multi_lockfile_two".to_string(),
     ]
+    .into_iter()
+    .map(|f| lockfile_from_path(&f).unwrap())
+    .collect();
+    resolve_lockfile_packages(&files).unwrap()
 }
 
 #[test]
@@ -15,7 +22,7 @@ fn test_multi_file_normal_mode() {
     let mut mint = Mint::new("tests/support");
     let mut file = mint.new_goldenfile("multi_file_normal").unwrap();
 
-    let packages = read_packages_from_lockfiles(&lockfiles()).unwrap();
+    let packages = lockfiles();
     let output = format_cargo_crates(packages, AlignmentMode::Normal);
 
     writeln!(file, "{}", output).unwrap();
@@ -26,7 +33,7 @@ fn test_multi_file_maxlen_mode() {
     let mut mint = Mint::new("tests/support");
     let mut file = mint.new_goldenfile("multi_file_maxlen").unwrap();
 
-    let packages = read_packages_from_lockfiles(&lockfiles()).unwrap();
+    let packages = lockfiles();
     let output = format_cargo_crates(packages, AlignmentMode::Maxlen);
 
     writeln!(file, "{}", output).unwrap();
@@ -37,7 +44,7 @@ fn test_multi_file_multiline_mode() {
     let mut mint = Mint::new("tests/support");
     let mut file = mint.new_goldenfile("multi_file_multiline").unwrap();
 
-    let packages = read_packages_from_lockfiles(&lockfiles()).unwrap();
+    let packages = lockfiles();
     let output = format_cargo_crates(packages, AlignmentMode::Multiline);
 
     writeln!(file, "{}", output).unwrap();
@@ -48,7 +55,7 @@ fn test_multi_file_justify_mode() {
     let mut mint = Mint::new("tests/support");
     let mut file = mint.new_goldenfile("multi_file_justify").unwrap();
 
-    let packages = read_packages_from_lockfiles(&lockfiles()).unwrap();
+    let packages = lockfiles();
     let output = format_cargo_crates(packages, AlignmentMode::Justify);
 
     writeln!(file, "{}", output).unwrap();

--- a/tests/one_file_test.rs
+++ b/tests/one_file_test.rs
@@ -1,10 +1,17 @@
 use std::io::Write;
 
-use cargo2port::{format_cargo_crates, read_packages_from_lockfiles, AlignmentMode};
+use cargo2port::{
+    format_cargo_crates, lockfile_from_path, resolve_lockfile_packages, AlignmentMode,
+};
+use cargo_lock::Package;
 use goldenfile::Mint;
 
-fn lockfiles() -> Vec<String> {
-    vec!["Cargo.lock".to_string()]
+fn lockfiles() -> Vec<Package> {
+    let files = vec!["Cargo.lock".to_string()]
+        .into_iter()
+        .map(|f| lockfile_from_path(&f).unwrap())
+        .collect();
+    resolve_lockfile_packages(&files).unwrap()
 }
 
 #[test]
@@ -12,7 +19,7 @@ fn test_one_file_normal_mode() {
     let mut mint = Mint::new("tests/support");
     let mut file = mint.new_goldenfile("one_file_normal").unwrap();
 
-    let packages = read_packages_from_lockfiles(&lockfiles()).unwrap();
+    let packages = lockfiles();
     let output = format_cargo_crates(packages, AlignmentMode::Normal);
 
     writeln!(file, "{}", output).unwrap();
@@ -23,7 +30,7 @@ fn test_one_file_maxlen_mode() {
     let mut mint = Mint::new("tests/support");
     let mut file = mint.new_goldenfile("one_file_maxlen").unwrap();
 
-    let packages = read_packages_from_lockfiles(&lockfiles()).unwrap();
+    let packages = lockfiles();
     let output = format_cargo_crates(packages, AlignmentMode::Maxlen);
 
     writeln!(file, "{}", output).unwrap();
@@ -34,7 +41,7 @@ fn test_one_file_multiline_mode() {
     let mut mint = Mint::new("tests/support");
     let mut file = mint.new_goldenfile("one_file_multiline").unwrap();
 
-    let packages = read_packages_from_lockfiles(&lockfiles()).unwrap();
+    let packages = lockfiles();
     let output = format_cargo_crates(packages, AlignmentMode::Multiline);
 
     writeln!(file, "{}", output).unwrap();
@@ -45,7 +52,7 @@ fn test_one_file_justify_mode() {
     let mut mint = Mint::new("tests/support");
     let mut file = mint.new_goldenfile("one_file_justify").unwrap();
 
-    let packages = read_packages_from_lockfiles(&lockfiles()).unwrap();
+    let packages = lockfiles();
     let output = format_cargo_crates(packages, AlignmentMode::Justify);
 
     writeln!(file, "{}", output).unwrap();


### PR DESCRIPTION
When src/lib.rs was added, cargo2port was made available for library use, but the functions were still organized in such a way as to reflect the cargo2port command line.

This refactors the library code to make the functions more usable outside of the cargo2port command line context.