### PR TITLE
Add -P flag to update cargo.crates block in a Portfile in-place

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,3 +148,64 @@ pub fn format_cargo_crates(packages: Vec<Package>, mode: AlignmentMode) -> Strin
 
     output
 }
+
+/// Splice a new `cargo.crates` block into a Portfile's contents,
+/// replacing the existing block.
+///
+/// Returns `None` if no existing `cargo.crates` block is found.
+pub fn splice_cargo_crates(portfile_contents: &str, cargo_crates_block: &str) -> Option<String> {
+    let lines: Vec<&str> = portfile_contents.lines().collect();
+
+    // Find the start of the cargo.crates block.
+    // Matches "cargo.crates" optionally followed by whitespace and a backslash.
+    let start = lines.iter().position(|line| {
+        let trimmed = line.trim();
+        if !trimmed.starts_with("cargo.crates") {
+            return false;
+        }
+        let rest = trimmed["cargo.crates".len()..].trim();
+        rest.is_empty() || rest == "\\"
+    })?;
+
+    // Find the end of the block: continuation lines end with '\'
+    let mut end = start;
+    while end < lines.len() && lines[end].ends_with('\\') {
+        end += 1;
+    }
+    // `end` is now the last line of the block (the one without trailing \)
+
+    let mut output = String::new();
+
+    // Everything before the block
+    for line in &lines[..start] {
+        output.push_str(line);
+        output.push('\n');
+    }
+
+    // Match the indentation of the original cargo.crates line
+    let original_line = lines[start];
+    let content_start = original_line.len() - original_line.trim_start().len();
+    let indent = &original_line[..content_start];
+
+    // The new block, with original indentation applied
+    for (i, line) in cargo_crates_block.lines().enumerate() {
+        if i > 0 {
+            output.push('\n');
+        }
+        if !line.is_empty() {
+            output.push_str(indent);
+        }
+        output.push_str(line);
+    }
+    output.push('\n');
+
+    // Everything after the block
+    if end + 1 < lines.len() {
+        for line in &lines[end + 1..] {
+            output.push_str(line);
+            output.push('\n');
+        }
+    }
+
+    Some(output)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::fs;
 use std::path::Path;
 use std::process;
 
@@ -6,14 +7,16 @@ use cargo_lock::{Lockfile, Package};
 
 use cargo2port::{
     format_cargo_crates, lockfile_from_path, lockfile_from_stdin, resolve_lockfile_packages,
-    AlignmentMode, Result,
+    splice_cargo_crates, AlignmentMode, Result,
 };
 
 fn main() {
     let mut mode = AlignmentMode::Normal;
     let mut files: Vec<String> = vec![];
+    let mut portfile_path: Option<String> = None;
+    let mut args = env::args().skip(1);
 
-    for arg in env::args().skip(1) {
+    while let Some(arg) = args.next() {
         match &arg[..] {
             "" => continue,
             "--help" => print_usage(0),
@@ -22,6 +25,12 @@ fn main() {
             "--align=maxlen" => mode = AlignmentMode::Maxlen,
             "--align=multiline" => mode = AlignmentMode::Multiline,
             "--align=justify" => mode = AlignmentMode::Justify,
+            "-P" | "--portfile" => {
+                portfile_path = Some(args.next().unwrap_or_else(|| {
+                    eprintln!("Error: -P requires a path to a Portfile");
+                    process::exit(1);
+                }));
+            }
             _ => match check_path(&arg[..]) {
                 Some(path) => files.push(path),
                 None => process::exit(1),
@@ -40,13 +49,50 @@ fn main() {
                 process::exit(0);
             }
 
-            println!("{}", format_cargo_crates(packages, mode));
+            let block = format_cargo_crates(packages, mode);
+
+            match portfile_path {
+                Some(ref path) => update_portfile(path, &block),
+                None => println!("{}", block),
+            }
         }
         Err(error) => {
             eprintln!("{}", error);
             process::exit(1)
         }
     }
+}
+
+fn update_portfile(path: &str, cargo_crates_block: &str) {
+    let portfile_path = Path::new(path);
+
+    let contents = fs::read_to_string(portfile_path).unwrap_or_else(|e| {
+        eprintln!("Error reading Portfile '{}': {}", path, e);
+        process::exit(1);
+    });
+
+    let updated = splice_cargo_crates(&contents, cargo_crates_block).unwrap_or_else(|| {
+        eprintln!("Error: no cargo.crates block found in '{}'", path);
+        process::exit(1);
+    });
+
+    // Write to a temporary file in the same directory, then rename into place
+    // so the Portfile is never left in a partially-written state.
+    let dir = portfile_path.parent().unwrap_or(Path::new("."));
+    let tmp_path = dir.join(".Portfile.cargo2port.tmp");
+
+    fs::write(&tmp_path, &updated).unwrap_or_else(|e| {
+        eprintln!("Error writing temporary file '{}': {}", tmp_path.display(), e);
+        process::exit(1);
+    });
+
+    fs::rename(&tmp_path, portfile_path).unwrap_or_else(|e| {
+        let _ = fs::remove_file(&tmp_path);
+        eprintln!("Error replacing Portfile '{}': {}", path, e);
+        process::exit(1);
+    });
+
+    eprintln!("Updated {}", path);
 }
 
 fn check_path(arg: &str) -> Option<String> {
@@ -102,7 +148,15 @@ fn read_packages_from_lockfiles(files: &Vec<String>) -> Result<Vec<Package>> {
 fn print_usage(code: i32) {
     let arg0 = env::args().next().unwrap_or("cargo2port".to_owned());
     eprintln!(
-        "Usage: {} [--align=maxlen|multiline|justify] <path/to/Cargo.lock>...",
+        "Usage: {} [options] <path/to/Cargo.lock>...
+
+Generate a cargo.crates block for a MacPorts Portfile from one or more
+Cargo.lock files. By default the block is printed to stdout.
+
+Options:
+  -h, --help                            Print this help message
+  --align=maxlen|multiline|justify      Set alignment mode
+  -P, --portfile <path>                 Update the cargo.crates block in <path> in place",
         arg0
     );
     process::exit(code);

--- a/tests/splice_test.rs
+++ b/tests/splice_test.rs
@@ -1,0 +1,178 @@
+use std::io::Write;
+
+use cargo2port::splice_cargo_crates;
+use goldenfile::Mint;
+
+#[test]
+fn test_splice_replaces_existing_block() {
+    let mut mint = Mint::new("tests/support");
+    let mut file = mint.new_goldenfile("splice_replace").unwrap();
+
+    let portfile = "\
+PortSystem          1.0
+PortGroup           cargo 1.0
+
+cargo.crates \\
+    foo 1.0.0 abc123 \\
+    bar 2.0.0 def456
+
+checksums           rmd160 abc
+";
+
+    let new_block = "cargo.crates \\
+    baz 3.0.0 aaa111";
+
+    let result = splice_cargo_crates(portfile, new_block).unwrap();
+    write!(file, "{}", result).unwrap();
+}
+
+#[test]
+fn test_splice_preserves_surrounding_content() {
+    let mut mint = Mint::new("tests/support");
+    let mut file = mint.new_goldenfile("splice_surrounding").unwrap();
+
+    let portfile = "\
+# header
+cargo.crates \\
+    old 1.0.0 aaa
+# footer
+";
+
+    let new_block = "cargo.crates \\
+    new 2.0.0 bbb";
+
+    let result = splice_cargo_crates(portfile, new_block).unwrap();
+    write!(file, "{}", result).unwrap();
+}
+
+#[test]
+fn test_splice_returns_none_when_no_block() {
+    let portfile = "\
+PortSystem          1.0
+PortGroup           cargo 1.0
+";
+
+    let new_block = "cargo.crates \\
+    foo 1.0.0 abc123";
+
+    assert!(splice_cargo_crates(portfile, new_block).is_none());
+}
+
+#[test]
+fn test_splice_block_at_end_of_file() {
+    let mut mint = Mint::new("tests/support");
+    let mut file = mint.new_goldenfile("splice_end_of_file").unwrap();
+
+    let portfile = "\
+PortSystem          1.0
+
+cargo.crates \\
+    old 1.0.0 aaa
+";
+
+    let new_block = "cargo.crates \\
+    new 2.0.0 bbb";
+
+    let result = splice_cargo_crates(portfile, new_block).unwrap();
+    write!(file, "{}", result).unwrap();
+}
+
+#[test]
+fn test_splice_single_line_block_no_continuation() {
+    let mut mint = Mint::new("tests/support");
+    let mut file = mint.new_goldenfile("splice_single_line").unwrap();
+
+    let portfile = "\
+before
+cargo.crates
+after
+";
+
+    let new_block = "cargo.crates \\
+    foo 1.0.0 abc123";
+
+    let result = splice_cargo_crates(portfile, new_block).unwrap();
+    write!(file, "{}", result).unwrap();
+}
+
+#[test]
+fn test_splice_preserves_content_order() {
+    let mut mint = Mint::new("tests/support");
+    let mut file = mint.new_goldenfile("splice_content_order").unwrap();
+
+    let portfile = "\
+line1
+line2
+cargo.crates \\
+    old 1.0.0 aaa \\
+    old2 2.0.0 bbb
+line3
+line4
+";
+
+    let new_block = "cargo.crates \\
+    new 3.0.0 ccc";
+
+    let result = splice_cargo_crates(portfile, new_block).unwrap();
+    write!(file, "{}", result).unwrap();
+}
+
+#[test]
+fn test_splice_matches_multiple_spaces_before_continuation() {
+    let mut mint = Mint::new("tests/support");
+    let mut file = mint.new_goldenfile("splice_multi_space").unwrap();
+
+    let portfile = "\
+before
+cargo.crates      \\
+    old 1.0.0 aaa
+after
+";
+
+    let new_block = "cargo.crates \\
+    new 2.0.0 bbb";
+
+    let result = splice_cargo_crates(portfile, new_block).unwrap();
+    write!(file, "{}", result).unwrap();
+}
+
+#[test]
+fn test_splice_preserves_original_indentation() {
+    let mut mint = Mint::new("tests/support");
+    let mut file = mint.new_goldenfile("splice_indentation").unwrap();
+
+    let portfile = "\
+before
+  cargo.crates \\
+      old 1.0.0 aaa
+after
+";
+
+    let new_block = "cargo.crates \\
+    new 2.0.0 bbb";
+
+    let result = splice_cargo_crates(portfile, new_block).unwrap();
+    write!(file, "{}", result).unwrap();
+}
+
+#[test]
+fn test_splice_preserves_subport_indentation() {
+    let mut mint = Mint::new("tests/support");
+    let mut file = mint.new_goldenfile("splice_subport").unwrap();
+
+    let portfile = "\
+PortSystem          1.0
+
+subport foo-bar {
+    cargo.crates \\
+        old 1.0.0 aaa \\
+        old2 2.0.0 bbb
+}
+";
+
+    let new_block = "cargo.crates \\
+    new 3.0.0 ccc";
+
+    let result = splice_cargo_crates(portfile, new_block).unwrap();
+    write!(file, "{}", result).unwrap();
+}

--- a/tests/support/splice_content_order
+++ b/tests/support/splice_content_order
@@ -1,0 +1,6 @@
+line1
+line2
+cargo.crates \
+    new 3.0.0 ccc
+line3
+line4

--- a/tests/support/splice_end_of_file
+++ b/tests/support/splice_end_of_file
@@ -1,0 +1,4 @@
+PortSystem          1.0
+
+cargo.crates \
+    new 2.0.0 bbb

--- a/tests/support/splice_indentation
+++ b/tests/support/splice_indentation
@@ -1,0 +1,4 @@
+before
+  cargo.crates \
+      new 2.0.0 bbb
+after

--- a/tests/support/splice_multi_space
+++ b/tests/support/splice_multi_space
@@ -1,0 +1,4 @@
+before
+cargo.crates \
+    new 2.0.0 bbb
+after

--- a/tests/support/splice_replace
+++ b/tests/support/splice_replace
@@ -1,0 +1,7 @@
+PortSystem          1.0
+PortGroup           cargo 1.0
+
+cargo.crates \
+    baz 3.0.0 aaa111
+
+checksums           rmd160 abc

--- a/tests/support/splice_single_line
+++ b/tests/support/splice_single_line
@@ -1,0 +1,4 @@
+before
+cargo.crates \
+    foo 1.0.0 abc123
+after

--- a/tests/support/splice_subport
+++ b/tests/support/splice_subport
@@ -1,0 +1,6 @@
+PortSystem          1.0
+
+subport foo-bar {
+    cargo.crates \
+        new 3.0.0 ccc
+}

--- a/tests/support/splice_surrounding
+++ b/tests/support/splice_surrounding
@@ -1,0 +1,4 @@
+# header
+cargo.crates \
+    new 2.0.0 bbb
+# footer


### PR DESCRIPTION
Given one or more Cargo.lock files and a path to a Portfile, generate the cargo.crates block and splice it into the Portfile, replacing the existing block. Errors if no cargo.crates block is found.

Example:

    cargo2port -P ~/ports/sysutils/broot/Portfile
    cargo2port --align=justify -P ~/ports/sysutils/broot/Portfile